### PR TITLE
Make each news item a dedicated page

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <nav class="hidden md:flex space-x-8">
         <a href="#services" class="hover:text-blue-600 transition">Services</a>
         <a href="#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="news.html" class="hover:text-blue-600 transition">News</a>
         <a href="#team" class="hover:text-blue-600 transition">Team</a>
         <a href="#contact" class="hover:text-blue-600 transition">Contact</a>
       </nav>
@@ -36,6 +37,7 @@
     <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
       <a href="#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
       <a href="#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
       <a href="#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
       <a href="#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
     </nav>
@@ -88,6 +90,8 @@
         </div>
       </div>
     </section>
+
+
 
     <!-- Team Section -->
     <section id="team" class="container mx-auto px-6 py-16">

--- a/news.html
+++ b/news.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>News - der BioIT</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/feather-icons"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800 font-inter leading-relaxed">
+  <header id="siteHeader" class="bg-white shadow w-full">
+    <div class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="index.html" class="logo">
+        <img src="pictures/logo.svg" alt="der BioIT Logo" class="h-10" />
+      </a>
+      <nav class="hidden md:flex space-x-8">
+        <a href="index.html#services" class="hover:text-blue-600 transition">Services</a>
+        <a href="index.html#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="news.html" class="hover:text-blue-600 transition">News</a>
+        <a href="index.html#team" class="hover:text-blue-600 transition">Team</a>
+        <a href="index.html#contact" class="hover:text-blue-600 transition">Contact</a>
+      </nav>
+      <div class="flex items-center space-x-4">
+        <a href="index.html#contact" class="bg-blue-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-500 transition">Get Started</a>
+        <button id="menuBtn" class="md:hidden focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
+      <a href="index.html#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
+      <a href="index.html#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
+      <a href="index.html#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
+      <a href="index.html#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold text-center text-blue-800 mb-12">News</h1>
+    <div class="space-y-6 max-w-3xl mx-auto">
+      <div class="bg-white shadow-lg rounded-lg p-6">
+        <h2 class="text-xl font-semibold mb-2">
+          <a href="news/started-prs-project-with-humess-2024.html" class="text-blue-700 hover:underline">2024 - Started the PRS project with humess</a>
+        </h2>
+        <p>We partnered with humess to develop an interactive platform for polygenic risk score calculation, enabling real-time charts and simplified API integrations.</p>
+      </div>
+      <div class="bg-white shadow-lg rounded-lg p-6">
+        <h2 class="text-xl font-semibold mb-2">
+          <a href="news/finished-the-leogen-project-2023.html" class="text-blue-700 hover:underline">2023 - Finished the Leogen Project</a>
+        </h2>
+        <p>Successfully delivered a WES pipeline for analyzing diagnostic samples of paraffin-embedded embryos, providing a robust solution for clinical research.</p>
+      </div>
+      <div class="bg-white shadow-lg rounded-lg p-6">
+        <h2 class="text-xl font-semibold mb-2">
+          <a href="news/introducing-the-leogen-project-2022.html" class="text-blue-700 hover:underline">2022 - Introducing the Leogen project</a>
+        </h2>
+        <p>The Leogen project kicked off, focusing on next-generation sequencing to support infertility diagnostics.</p>
+      </div>
+      <div class="bg-white shadow-lg rounded-lg p-6">
+        <h2 class="text-xl font-semibold mb-2">
+          <a href="news/introducing-the-team-2022.html" class="text-blue-700 hover:underline">2022 - Introducing the team</a>
+        </h2>
+        <p>der BioIT was founded by a group of passionate bioinformaticians and data scientists aiming to make personalized medicine more accessible.</p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="bg-gray-50 py-6 text-center text-gray-500 text-sm">
+    &copy; 2025 der BioIT • All rights reserved.
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+    feather.replace();
+  </script>
+</body>
+</html>

--- a/news/finished-the-leogen-project-2023.html
+++ b/news/finished-the-leogen-project-2023.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Finished the Leogen Project - 2023 - der BioIT</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/feather-icons"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800 font-inter leading-relaxed">
+  <header id="siteHeader" class="bg-white shadow w-full">
+    <div class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="../index.html" class="logo">
+        <img src="../pictures/logo.svg" alt="der BioIT Logo" class="h-10" />
+      </a>
+      <nav class="hidden md:flex space-x-8">
+        <a href="../index.html#services" class="hover:text-blue-600 transition">Services</a>
+        <a href="../index.html#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="../news.html" class="hover:text-blue-600 transition">News</a>
+        <a href="../index.html#team" class="hover:text-blue-600 transition">Team</a>
+        <a href="../index.html#contact" class="hover:text-blue-600 transition">Contact</a>
+      </nav>
+      <div class="flex items-center space-x-4">
+        <a href="../index.html#contact" class="bg-blue-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-500 transition">Get Started</a>
+        <button id="menuBtn" class="md:hidden focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
+      <a href="../index.html#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
+      <a href="../index.html#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="../news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
+      <a href="../index.html#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
+      <a href="../index.html#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold text-center text-blue-800 mb-6">Finished the Leogen Project – 2023</h1>
+    <div class="prose max-w-none mx-auto">
+      <p>We successfully delivered a WES pipeline for analyzing diagnostic samples of paraffin-embedded embryos, providing a robust solution for clinical research.</p>
+    </div>
+  </main>
+
+  <footer class="bg-gray-50 py-6 text-center text-gray-500 text-sm">
+    &copy; 2025 der BioIT • All rights reserved.
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+    feather.replace();
+  </script>
+</body>
+</html>

--- a/news/introducing-the-leogen-project-2022.html
+++ b/news/introducing-the-leogen-project-2022.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Introducing the Leogen Project - 2022 - der BioIT</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/feather-icons"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800 font-inter leading-relaxed">
+  <header id="siteHeader" class="bg-white shadow w-full">
+    <div class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="../index.html" class="logo">
+        <img src="../pictures/logo.svg" alt="der BioIT Logo" class="h-10" />
+      </a>
+      <nav class="hidden md:flex space-x-8">
+        <a href="../index.html#services" class="hover:text-blue-600 transition">Services</a>
+        <a href="../index.html#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="../news.html" class="hover:text-blue-600 transition">News</a>
+        <a href="../index.html#team" class="hover:text-blue-600 transition">Team</a>
+        <a href="../index.html#contact" class="hover:text-blue-600 transition">Contact</a>
+      </nav>
+      <div class="flex items-center space-x-4">
+        <a href="../index.html#contact" class="bg-blue-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-500 transition">Get Started</a>
+        <button id="menuBtn" class="md:hidden focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
+      <a href="../index.html#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
+      <a href="../index.html#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="../news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
+      <a href="../index.html#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
+      <a href="../index.html#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold text-center text-blue-800 mb-6">Introducing the Leogen project – 2022</h1>
+    <div class="prose max-w-none mx-auto">
+      <p>The Leogen project kicked off in 2022, focusing on next-generation sequencing to support infertility diagnostics.</p>
+    </div>
+  </main>
+
+  <footer class="bg-gray-50 py-6 text-center text-gray-500 text-sm">
+    &copy; 2025 der BioIT • All rights reserved.
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+    feather.replace();
+  </script>
+</body>
+</html>

--- a/news/introducing-the-team-2022.html
+++ b/news/introducing-the-team-2022.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Introducing the Team - 2022 - der BioIT</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/feather-icons"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800 font-inter leading-relaxed">
+  <header id="siteHeader" class="bg-white shadow w-full">
+    <div class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="../index.html" class="logo">
+        <img src="../pictures/logo.svg" alt="der BioIT Logo" class="h-10" />
+      </a>
+      <nav class="hidden md:flex space-x-8">
+        <a href="../index.html#services" class="hover:text-blue-600 transition">Services</a>
+        <a href="../index.html#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="../news.html" class="hover:text-blue-600 transition">News</a>
+        <a href="../index.html#team" class="hover:text-blue-600 transition">Team</a>
+        <a href="../index.html#contact" class="hover:text-blue-600 transition">Contact</a>
+      </nav>
+      <div class="flex items-center space-x-4">
+        <a href="../index.html#contact" class="bg-blue-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-500 transition">Get Started</a>
+        <button id="menuBtn" class="md:hidden focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
+      <a href="../index.html#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
+      <a href="../index.html#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="../news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
+      <a href="../index.html#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
+      <a href="../index.html#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold text-center text-blue-800 mb-6">Introducing the Team – 2022</h1>
+    <div class="prose max-w-none mx-auto">
+      <p>In 2022, der BioIT was born — not as a company with a product, but as a collective of people with a mission.</p>
+      <p>At its core, der BioIT is a response to a shared frustration: bioinformatics is often too expensive, too inaccessible, and too complicated for the people who need it most. We knew there had to be a better way — so we set out to build it.</p>
+      <p>The founding team came together from diverse corners of science and industry. Matvii brought hands-on experience from diagnostics and clinical genomics; Nadiia, a background in public health and strategy; Dariia, nonprofit leadership and organizational vision. Anna shaped our communications and outreach efforts, Yuliia architected our software frameworks, and Liliia infused fresh energy and data science curiosity into everything we touched.</p>
+      <p>From day one, we made three things non-negotiable:<br>Openness. Practicality. People-first design.</p>
+      <p>We didn’t want to build “just another pipeline.” We wanted to create tools that clinicians could actually use, that researchers could actually afford, and that would scale across borders — from teaching hospitals in Europe to outreach labs in underserved regions.</p>
+      <p>2022 was our starting line. We spent countless hours testing open-source tools, sketching pipeline blueprints on café napkins, rewriting error logs at 2 a.m., and building something that felt grounded in reality but driven by ambition.</p>
+      <p>By the end of that year, we weren’t just colleagues — we were a team. A team committed to bringing modern bioinformatics to the people who need it most, without the usual gatekeeping. der BioIT is still growing, but it began with this simple idea:<br>Science should be shared. And good science should be usable.</p>
+      <p>Welcome to the beginning of that journey.</p>
+    </div>
+  </main>
+
+  <footer class="bg-gray-50 py-6 text-center text-gray-500 text-sm">
+    &copy; 2025 der BioIT • All rights reserved.
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+    feather.replace();
+  </script>
+</body>
+</html>

--- a/news/started-prs-project-with-humess-2024.html
+++ b/news/started-prs-project-with-humess-2024.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Started the PRS project with humess - 2024 - der BioIT</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://unpkg.com/feather-icons"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="bg-gray-50 text-gray-800 font-inter leading-relaxed">
+  <header id="siteHeader" class="bg-white shadow w-full">
+    <div class="container mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="../index.html" class="logo">
+        <img src="../pictures/logo.svg" alt="der BioIT Logo" class="h-10" />
+      </a>
+      <nav class="hidden md:flex space-x-8">
+        <a href="../index.html#services" class="hover:text-blue-600 transition">Services</a>
+        <a href="../index.html#projects" class="hover:text-blue-600 transition">Projects</a>
+        <a href="../news.html" class="hover:text-blue-600 transition">News</a>
+        <a href="../index.html#team" class="hover:text-blue-600 transition">Team</a>
+        <a href="../index.html#contact" class="hover:text-blue-600 transition">Contact</a>
+      </nav>
+      <div class="flex items-center space-x-4">
+        <a href="../index.html#contact" class="bg-blue-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-blue-500 transition">Get Started</a>
+        <button id="menuBtn" class="md:hidden focus:outline-none">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <nav id="mobileMenu" class="hidden bg-white shadow-lg md:hidden">
+      <a href="../index.html#services" class="block px-6 py-3 hover:bg-gray-100">Services</a>
+      <a href="../index.html#projects" class="block px-6 py-3 hover:bg-gray-100">Projects</a>
+      <a href="../news.html" class="block px-6 py-3 hover:bg-gray-100">News</a>
+      <a href="../index.html#team" class="block px-6 py-3 hover:bg-gray-100">Team</a>
+      <a href="../index.html#contact" class="block px-6 py-3 hover:bg-gray-100">Contact</a>
+    </nav>
+  </header>
+
+  <main class="container mx-auto px-6 py-16">
+    <h1 class="text-3xl font-bold text-center text-blue-800 mb-6">Started the PRS project with humess – 2024</h1>
+    <div class="prose max-w-none mx-auto">
+      <p>We partnered with humess to develop an interactive platform for polygenic risk score calculation, enabling real-time charts and simplified API integrations.</p>
+    </div>
+  </main>
+
+  <footer class="bg-gray-50 py-6 text-center text-gray-500 text-sm">
+    &copy; 2025 der BioIT • All rights reserved.
+  </footer>
+
+  <script>
+    const menuBtn = document.getElementById('menuBtn');
+    const mobileMenu = document.getElementById('mobileMenu');
+    menuBtn.addEventListener('click', () => {
+      mobileMenu.classList.toggle('hidden');
+    });
+    feather.replace();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create individual HTML pages under `news/` for each announcement
- update `news.html` to link to these pages instead of hosting full text
- add long-form content for "Introducing the Team – 2022"

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842b3eac36083219149085fa58ebcef